### PR TITLE
Add airbrake for errbit error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.1'
 gem 'rack-proxy'
 gem 'logstasher', '0.6.5'
+gem 'plek', '~> 1.10'
+gem 'airbrake', '~> 4.2.1'
 
 group :development, :test do
   gem 'rspec-rails', '3.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    airbrake (4.2.1)
+      builder
+      multi_json
     arel (6.0.0)
     builder (3.2.2)
     byebug (5.0.0)
@@ -65,6 +68,7 @@ GEM
     multi_json (1.11.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    plek (1.10.0)
     rack (1.6.1)
     rack-proxy (0.5.17)
       rack
@@ -139,8 +143,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  airbrake (~> 4.2.1)
   byebug
   logstasher (= 0.6.5)
+  plek (~> 1.10)
   rack-proxy
   rack-test (= 0.6.3)
   rails (= 4.2.1)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,10 @@
+if ENV['ERRBIT_API_KEY'].present?
+  errbit_uri = Plek.find_uri('errbit')
+
+  Airbrake.configure do |config|
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+  end
+end


### PR DESCRIPTION
This installs the dependencies and sets up an ENV-based configuration.
Additional changes will need to be made to puppet to set these env-vars and also to the hiera data for preview, staging and production.