### PR TITLE
Correct Rack::Proxy usage

### DIFF
--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -5,7 +5,7 @@ class Proxy < Rack::Proxy
 
   def initialize(app, upstream_url)
     @app = app
-    @upstream_url = URI.parse(upstream_url)
+    super(backend: upstream_url, streaming: false)
   end
 
   def call(env)
@@ -17,16 +17,11 @@ class Proxy < Rack::Proxy
   end
 
   def rewrite_env(env)
-    env['rack.url_scheme'] = upstream_url.scheme
-    env["HTTP_HOST"] = upstream_url.host
-    env['SERVER_PORT'] = upstream_url.port
-    # rack-proxy doesn't cope well with gzipped/deflated content
-    env.delete('HTTP_ACCEPT_ENCODING')
     # Here's where we will set the X-GOVUK-AUTHENTICATED-USER header
     env
   end
 
-   def rewrite_response(response)
+  def rewrite_response(response)
     status, headers, body = response
 
     [

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+require 'rack'
+
+RSpec.describe Proxy do
+  let(:upstream_body) { 'hello' }
+  let(:upstream_headers) do
+    {
+      'Content-Type' => 'text/plain',
+      'Transfer-Encoding' => 'chunked',
+      'Status' => '200 OK',
+    }
+  end
+  let(:upstream_path) { "/foo" }
+  let(:upstream_uri) { ENV['GOVUK_UPSTREAM_URI'] }
+  let(:inner_app) { lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['Rails App']] } }
+  let(:request_env) { Rack::MockRequest.env_for(upstream_path) }
+  let(:proxy_app) { Proxy.new(inner_app, upstream_uri) }
+
+  before do
+    stub_request(:get, upstream_uri + upstream_path).
+      to_return(body: upstream_body, status: 200, headers: upstream_headers)
+  end
+
+  it 'passes Rack::Lint checks' do
+    lint_app = Rack::Lint.new(Proxy.new(inner_app, upstream_uri))
+    lint_app.call(request_env)
+  end
+
+  it 'returns the response from the upstream URI' do
+    status, headers, body = proxy_app.call(request_env)
+
+    expect(body).to eq([upstream_body])
+  end
+
+  it 'does not proxy /healthcheck requests' do
+    status, headers, body = proxy_app.call(request_env.merge({ "PATH_INFO" => "/healthcheck"}))
+
+    expect(body).to eq(['Rails App'])
+  end
+end


### PR DESCRIPTION
The README is out of date and we were doing it wrong. These changes should get it working properly on the draft stack.