### PR TITLE
Fix authentication header

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,21 @@ so that the upstream service can identify the user.
 
 ### Running the application
 
+The application relies on the `GOVUK_UPSTREAM_URI` being set to run:
+
 ```
 $ GOVUK_UPSTREAM_URI=https://www.dev.gov.uk ./startup.sh
 ```
+
+To run the authenticating proxy on the development VM and route it through to
+government-frontend, you can `bowl` as follows:
+
+```
+$ GOVUK_UPSTREAM_URI=http://government-frontend.dev.gov.uk GDS_SSO_STRATEGY=real bowl authenticating-proxy
+```
+
+Note that `GDS_SSO_STRATEGY` is set to true to tell gds-sso not to use mock mode
+and authenticate via a real signon service.
 
 ### Running the test suite
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ An authenticating proxy application that proxies requests to an upstream service
 
 ## Nomenclature
 
-- **`X-GOVUK-AUTHENTICATED-USER`**: The HTTP header which contains the ID number
-   of the authenticated user (as reported by signonotron).
-- **upstream service**: The destination service that the app is proxying through to.
+- **`X-GOVUK-AUTHENTICATED-USER`**: The HTTP header which contains the UID of
+  the authenticated user (as reported by signonotron).
+- **upstream service**: The destination service that the app is proxying to.
 - **signonotron**: Single signon service for GOV.UK authentication.
 - **`GOVUK_UPSTREAM_URI`**: environment variable used to specify the upstream
   site.

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -56,7 +56,7 @@ private
 
   def add_authenticated_user_header(env)
     if env['warden']
-      env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = env['warden'].user.id.to_s
+      env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = env['warden'].user.uid.to_s
     end
   end
 

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Proxying requests", type: :request do
   end
 
   context "authenticated user" do
-    let(:authenticated_user_id) { User.first.id }
+    let(:authenticated_user_uid) { User.first.uid }
     before do
       stub_request(:get, upstream_uri + upstream_path).to_return(body: body)
       get upstream_path
@@ -31,9 +31,9 @@ RSpec.describe "Proxying requests", type: :request do
       expect(response.body).to eq(body)
     end
 
-    it "includes an identifier for the authenticated user in the upstream request headers" do
+    it "includes the user's UID in the upstream request headers" do
       expect(WebMock).to have_requested(:get, upstream_uri + upstream_path).
-        with(headers: { 'X-Govuk-Authenticated-User' => authenticated_user_id })
+        with(headers: { 'X-Govuk-Authenticated-User' => authenticated_user_uid })
     end
   end
 end


### PR DESCRIPTION
It was setting the User's "id" and not its "uid" from signon, which is not what we want.