### PR TITLE
Allow access via JWT for fact checking

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,5 +13,7 @@ module AuthenticatingProxy
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
+    config.jwt_auth_secret = ENV['JWT_AUTH_SECRET']
   end
 end

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -73,9 +73,11 @@ private
   end
 
   def add_authenticated_user_header(env)
-    if env['warden'] && env['warden'].user
-      env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = env['warden'].user.uid.to_s
-    end
+    env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = if env['warden'] && env['warden'].user
+                                               env['warden'].user.uid.to_s
+                                             else
+                                               'invalid'
+                                             end
   end
 
   def remove_token_param(env)

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -12,7 +12,7 @@ class Proxy < Rack::Proxy
     path = env['PATH_INFO']
 
     if proxy?(path)
-      authenticate!(env)
+      process_token_or_authenticate!(env)
       debug_logging(env, "Proxing request: #{path}")
       super
     else
@@ -29,6 +29,7 @@ class Proxy < Rack::Proxy
     # Proxying hangs in the VM unless the host header is explicitly overridden here.
     env['HTTP_HOST'] = upstream_url.host
     add_authenticated_user_header(env)
+    remove_token_param(env)
     env
   end
 
@@ -46,6 +47,24 @@ class Proxy < Rack::Proxy
 
 private
 
+  def jwt_auth_secret
+    Rails.application.config.jwt_auth_secret
+  end
+
+  def process_token_or_authenticate!(env)
+    request = Rack::Request.new(env)
+    if token = request.params['token']
+      content_id = process_token(token, env)
+    end
+    authenticate!(env) unless content_id
+  end
+
+  def process_token(token, env)
+    payload, header = JWT.decode(token, jwt_auth_secret, true, { algorithm: 'HS256' })
+    env['HTTP_GOVUK_FACT_CHECK_ID'] = payload['sub'] if payload.key?('sub')
+  rescue JWT::DecodeError
+  end
+
   def authenticate!(env)
     if env['warden']
       user = env['warden'].authenticate!
@@ -54,9 +73,14 @@ private
   end
 
   def add_authenticated_user_header(env)
-    if env['warden']
+    if env['warden'] && env['warden'].user
       env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = env['warden'].user.uid.to_s
     end
+  end
+
+  def remove_token_param(env)
+    values = CGI.parse(env['QUERY_STRING']).except('token')
+    env['QUERY_STRING'] = URI.encode_www_form(values)
   end
 
   def healthcheck_path?(path)

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe "Proxying requests", type: :request do
         expect(response.status).to eq(200)
       end
 
+      it "marks the user id as invalid in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri + upstream_path).
+        with(headers: { 'X-Govuk-Authenticated-User' => 'invalid' })
+      end
+
       context "with an invalid token" do
         let(:token) { JWT.encode({ 'sub' => fact_check_id }, 'invalid', 'HS256') }
         it "redirects the user for authentication" do

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -18,6 +18,46 @@ RSpec.describe "Proxying requests", type: :request do
       expect(response.status).to eq(302)
       expect(response["Location"]).to eq("http://www.example.com/auth/gds")
     end
+
+    context "with a JWT token" do
+      let(:jwt_auth_secret) { 'my$ecretK3y' }
+      let(:fact_check_id) { SecureRandom.uuid }
+      let(:token) { JWT.encode({ 'sub' => fact_check_id }, jwt_auth_secret, 'HS256') }
+      before do
+        allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
+        stub_request(:get, upstream_uri + upstream_path).to_return(body: body)
+        get "#{upstream_path}?token=#{token}"
+      end
+
+      it "includes the decoded fact_check_id in the upstream request headers" do
+        expect(WebMock).to have_requested(:get, upstream_uri + upstream_path).
+          with(headers: { 'Govuk-Fact-Check-Id' => fact_check_id })
+      end
+
+      it "does not redirect the user for authentication" do
+        expect(response.status).to eq(200)
+      end
+
+      context "with an invalid token" do
+        let(:token) { JWT.encode({ 'sub' => fact_check_id }, 'invalid', 'HS256') }
+        it "redirects the user for authentication" do
+          get upstream_path
+
+          expect(response.status).to eq(302)
+          expect(response["Location"]).to eq("http://www.example.com/auth/gds")
+        end
+      end
+
+      context "with a token that is valid but doesn't contain the right key" do
+        let(:token) { JWT.encode({ 'foo' => 'bar' }, 'invalid', 'HS256') }
+        it "redirects the user for authentication" do
+          get upstream_path
+
+          expect(response.status).to eq(302)
+          expect(response["Location"]).to eq("http://www.example.com/auth/gds")
+        end
+      end
+    end
   end
 
   context "authenticated user" do


### PR DESCRIPTION
This accepts a querystring parameter `token`, consisting of a JWT
containing a subject claim for a fact check id. If the token is valid,
the fact_check_id is passed upstream in the GOVUK_FACT_CHECK_ID header.

Note that this app does not do anything to verify the fact_check_id
itself; that will be done by content-store.

Decoding the token relies on the JWT_AUTH_SECRET env var; the same
value will need to be shared with any publishing app that wants to
generate a token to be used for fact checking.