### PR TITLE
Add token to the upstream URL

### DIFF
--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -29,7 +29,6 @@ class Proxy < Rack::Proxy
     # Proxying hangs in the VM unless the host header is explicitly overridden here.
     env['HTTP_HOST'] = upstream_url.host
     add_authenticated_user_header(env)
-    remove_token_param(env)
     env
   end
 
@@ -78,11 +77,6 @@ private
                                              else
                                                'invalid'
                                              end
-  end
-
-  def remove_token_param(env)
-    values = CGI.parse(env['QUERY_STRING']).except('token')
-    env['QUERY_STRING'] = URI.encode_www_form(values)
   end
 
   def healthcheck_path?(path)

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe "Proxying requests", type: :request do
       let(:token) { JWT.encode({ 'sub' => fact_check_id }, jwt_auth_secret, 'HS256') }
       before do
         allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
-        stub_request(:get, upstream_uri + upstream_path).to_return(body: body)
+        stub_request(:get, upstream_uri + upstream_path + "?token=#{token}").to_return(body: body)
         get "#{upstream_path}?token=#{token}"
       end
 
       it "includes the decoded fact_check_id in the upstream request headers" do
-        expect(WebMock).to have_requested(:get, upstream_uri + upstream_path).
+        expect(WebMock).to have_requested(:get, upstream_uri + upstream_path + "?token=#{token}").
           with(headers: { 'Govuk-Fact-Check-Id' => fact_check_id })
       end
 
@@ -39,7 +39,7 @@ RSpec.describe "Proxying requests", type: :request do
       end
 
       it "marks the user id as invalid in the upstream request headers" do
-      expect(WebMock).to have_requested(:get, upstream_uri + upstream_path).
+      expect(WebMock).to have_requested(:get, upstream_uri + upstream_path + "?token=#{token}").
         with(headers: { 'X-Govuk-Authenticated-User' => 'invalid' })
       end
 


### PR DESCRIPTION
Frontend apps need to be able to access the encrypted web token so
they can generate viable internal URLs.

I can't see a real need to have the token filtered out at the proxy,
so here we add it back in. It's preferable to sharing the encryption
key with all the frontend apps.