### PR TITLE
Rename fact_check_id to auth_bypass_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ An authenticating proxy application that proxies requests to an upstream service
 - **signonotron**: Single signon service for GOV.UK authentication.
 - **`GOVUK_UPSTREAM_URI`**: environment variable used to specify the upstream
   site.
-- **`GOVUK_FACT_CHECK_ID`**: The HTTP header which contains the UUID of a fact
-  check, extracted from a token.
+- **`GOVUK_AUTH_BYPASS_ID`**: The HTTP header which contains the UUID of a auth
+  bypass, extracted from a token.
 
 ## Technical documentation
 
@@ -28,9 +28,9 @@ The application also supports bypassing authentication via a valid JWT token.
 If the URL being requested includes a `token` querystring containing a valid
 token encoded with the value in the `JWT_AUTH_SECRET` environment variable, and
 that token contains a `sub` key, the value of that key is passed upstream in
-the `GOVUK_FACT_CHECK_ID` header and authentication is not performed.
+the `GOVUK_AUTH_BYPASS_ID` header and authentication is not performed.
 
-Authenticating-proxy does not itself check that the fact_check_id is actually
+Authenticating-proxy does not itself check that the auth_bypass_id is actually
 valid; this will be done by content-store.
 
 ### Dependencies
@@ -74,18 +74,18 @@ $ bundle exec rake users:create name='User Name' email=user@email.com applicatio
 $ bundle exec rspec
 ```
 
-### Generating a fact check token
+### Generating a auth bypass token
 
-Applications which want to generate a token valid for fact checking will need to
-have access to the same value for the JWT_AUTH_SECRET environment variable. They
-can then use the JWT library - which will probably already be present, since it
+Applications which want to generate a token valid for bypassing authentication will
+need to have access to the same value for the JWT_AUTH_SECRET environment variable.
+They can then use the JWT library - which will probably already be present, since it
 is a dependency of gds-sso via oauth2 - to encode a token as follows:
 
 ```
-JWT.encode({ 'sub' => fact_check_id }, jwt_auth_secret, 'HS256')
+JWT.encode({ 'sub' => auth_bypass_id }, jwt_auth_secret, 'HS256')
 ```
 
-where `fact_check_id` is the UUID for the fact check of the content item, and
+where `auth_bypass_id` is the UUID for the auth bypass of the content item, and
 `jwt_auth_secret` is the secret supplied in the environment variable.
 
 ## Licence

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -60,7 +60,7 @@ private
 
   def process_token(token, env)
     payload, header = JWT.decode(token, jwt_auth_secret, true, { algorithm: 'HS256' })
-    env['HTTP_GOVUK_FACT_CHECK_ID'] = payload['sub'] if payload.key?('sub')
+    env['HTTP_GOVUK_AUTH_BYPASS_ID'] = payload['sub'] if payload.key?('sub')
   rescue JWT::DecodeError
   end
 

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -21,17 +21,17 @@ RSpec.describe "Proxying requests", type: :request do
 
     context "with a JWT token" do
       let(:jwt_auth_secret) { 'my$ecretK3y' }
-      let(:fact_check_id) { SecureRandom.uuid }
-      let(:token) { JWT.encode({ 'sub' => fact_check_id }, jwt_auth_secret, 'HS256') }
+      let(:auth_bypass_id) { SecureRandom.uuid }
+      let(:token) { JWT.encode({ 'sub' => auth_bypass_id }, jwt_auth_secret, 'HS256') }
       before do
         allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
         stub_request(:get, upstream_uri + upstream_path + "?token=#{token}").to_return(body: body)
         get "#{upstream_path}?token=#{token}"
       end
 
-      it "includes the decoded fact_check_id in the upstream request headers" do
+      it "includes the decoded auth_bypass_id in the upstream request headers" do
         expect(WebMock).to have_requested(:get, upstream_uri + upstream_path + "?token=#{token}").
-          with(headers: { 'Govuk-Fact-Check-Id' => fact_check_id })
+          with(headers: { 'Govuk-Auth-Bypass-Id' => auth_bypass_id })
       end
 
       it "does not redirect the user for authentication" do
@@ -44,7 +44,7 @@ RSpec.describe "Proxying requests", type: :request do
       end
 
       context "with an invalid token" do
-        let(:token) { JWT.encode({ 'sub' => fact_check_id }, 'invalid', 'HS256') }
+        let(:token) { JWT.encode({ 'sub' => auth_bypass_id }, 'invalid', 'HS256') }
         it "redirects the user for authentication" do
           get upstream_path
 


### PR DESCRIPTION
Content needs to be previewable by users without signon accounts in most stages of a publishers workflow, not just during fact check.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id