### PR TITLE
Don't meddle with the response transfer headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'govuk_app_config', '~> 0.2.0'
 group :development, :test do
   gem 'rspec-rails', '3.5.2'
   gem 'rack-test', '0.6.3'
-  gem 'webmock', '2.1.0', require: false
   gem 'byebug'
   gem 'simplecov', '0.8.2', :require => false
   gem 'simplecov-rcov', '0.2.3', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,14 +38,11 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.4.0)
     arel (7.1.2)
     bson (4.1.1)
     builder (3.2.2)
     byebug (9.0.6)
     concurrent-ruby (1.0.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
@@ -64,7 +61,6 @@ GEM
     govuk_app_config (0.2.0)
       sentry-raven (~> 2.6.3)
       statsd-ruby (~> 1.4.0)
-    hashdiff (0.3.0)
     hashie (3.4.6)
     i18n (0.7.0)
     jwt (1.5.6)
@@ -160,7 +156,6 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    safe_yaml (1.0.4)
     sentry-raven (2.6.3)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.8.2)
@@ -190,10 +185,6 @@ GEM
       rack (>= 1.0)
     warden-oauth2 (0.0.1)
       warden
-    webmock (2.1.0)
-      addressable (>= 2.3.6)
-      crack (>= 0.3.2)
-      hashdiff
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -215,7 +206,6 @@ DEPENDENCIES
   simplecov (= 0.8.2)
   simplecov-rcov (= 0.2.3)
   unicorn (= 4.9.0)
-  webmock (= 2.1.0)
 
 BUNDLED WITH
-   1.13.7
+   1.15.1

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -5,7 +5,7 @@ class Proxy < Rack::Proxy
 
   def initialize(app, upstream_url)
     @upstream_url = URI(upstream_url)
-    super(app, backend: upstream_url, streaming: false)
+    super(app, backend: upstream_url)
   end
 
   def call(env)
@@ -37,9 +37,8 @@ class Proxy < Rack::Proxy
 
     [
       status,
-      # We aren't returning a chunked response so remove that from the headers.
-      # Also, status doesn't belong in the headers in a rack response triplet.
-      headers.reject { |key, _| %w(status transfer-encoding).include?(key) },
+      # Status doesn't belong in the headers in a rack response triplet.
+      headers.reject { |key, _| key == "status" },
       body
     ]
   end

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -16,17 +16,19 @@ RSpec.describe Proxy do
   let(:request_env) { Rack::MockRequest.env_for(upstream_path) }
   let(:proxy_app) { Proxy.new(inner_app, upstream_uri) }
 
-  before do
-    stub_request(:get, upstream_uri + upstream_path).
-      to_return(body: upstream_body, status: 200, headers: upstream_headers)
-  end
-
   it 'passes Rack::Lint checks' do
-    lint_app = Rack::Lint.new(Proxy.new(inner_app, upstream_uri))
+    allow(proxy_app).to receive(:perform_request)
+      .and_return([200, {"Content-Type" => "text/html; charset=UTF-8"}, ["hello"]])
+
+    lint_app = Rack::Lint.new(proxy_app)
+
     lint_app.call(request_env)
   end
 
   it 'returns the response from the upstream URI' do
+    allow(proxy_app).to receive(:perform_request)
+      .and_return([200, {"Content-Type" => "text/html; charset=UTF-8"}, ["hello"]])
+
     status, headers, body = proxy_app.call(request_env)
 
     expect(body).to eq([upstream_body])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,6 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'rack/test'
-require 'webmock/rspec'
 require 'simplecov'
 require 'simplecov-rcov'
 SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter


### PR DESCRIPTION
We think this is the cause of these two Zendesk tickets:
https://govuk.zendesk.com/agent/tickets/2129122
https://govuk.zendesk.com/agent/tickets/2456890

Unfortunately, the commit message that introduced this
code didn't explain why it was added. I don't think
this is actually true:
>We aren't returning a chunked response

Applications behind the proxy may or may not set this
header and we shouldn't assume they don't. In the case
of Whitehall, it's likely setting this header to
'chunked' when responding with uploaded text files.