### PR TITLE
Patch Content-Length header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '5.0.0.1'
-gem 'rack-proxy', '0.6.0'
+gem 'rack-proxy', '~> 0.6.0'
 gem 'logstasher', '0.6.5'
 gem 'plek', '~> 1.10'
 gem 'unicorn', '4.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,8 @@ GEM
       omniauth (~> 1.2)
     pkg-config (1.1.7)
     plek (1.12.0)
-    rack (2.0.1)
-    rack-proxy (0.6.0)
+    rack (2.0.3)
+    rack-proxy (0.6.2)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -208,7 +208,7 @@ DEPENDENCIES
   logstasher (= 0.6.5)
   mongoid (= 6.0.0)
   plek (~> 1.10)
-  rack-proxy (= 0.6.0)
+  rack-proxy (~> 0.6.0)
   rack-test (= 0.6.3)
   rails (= 5.0.0.1)
   rspec-rails (= 3.5.2)
@@ -218,4 +218,4 @@ DEPENDENCIES
   webmock (= 2.1.0)
 
 BUNDLED WITH
-   1.13.7
+   1.15.1

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -37,9 +37,8 @@ class Proxy < Rack::Proxy
 
     [
       status,
-      # We aren't returning a chunked response so remove that from the headers.
-      # Also, status doesn't belong in the headers in a rack response triplet.
-      headers.reject { |key, _| %w(status transfer-encoding).include?(key) },
+      # Status doesn't belong in the headers in a rack response triplet.
+      headers.reject { |key, _| %w(status).include?(key) },
       body
     ]
   end

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -35,6 +35,8 @@ class Proxy < Rack::Proxy
   def rewrite_response(response)
     status, headers, body = response
 
+    fix_content_length(headers, body)
+
     [
       status,
       # Status doesn't belong in the headers in a rack response triplet.
@@ -88,5 +90,21 @@ private
 
   def debug_logging(env, message)
     env['action_dispatch.logger'] and env['action_dispatch.logger'].debug message
+  end
+
+  # Content-Length header can end up with an incorrect value as Net::HTTP will
+  # decompress a body of a gzipped request but pass throguh the Content-Length
+  # header of the compressed content.
+  def fix_content_length(headers, body)
+    content_length_header = headers.keys.find { |k| k.downcase == "content-length" }
+    return unless content_length_header
+
+    if body.all? { |b| b.respond_to?(:bytesize) }
+      bytesize = body.map(&:bytesize).sum
+      headers[content_length_header] = bytesize.to_s
+    else
+      headers.delete(content_length_header)
+    end
+    bytesize = body.map(&:bytesize)
   end
 end

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -37,4 +37,14 @@ RSpec.describe Proxy do
 
     expect(body).to eq(['Rails App'])
   end
+
+  describe "#rewrite_response" do
+    let(:status) { 200 }
+    let(:body) { ["1234 1234 1234 1234"] }
+    let(:response) { [status, { "Content-Length" => "5" }, body] }
+    it "corrects an incorrect content-length header" do
+      rewrote = proxy_app.rewrite_response(response)
+      expect(rewrote).to match([status, { "Content-Length" => "19" }, body])
+    end
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/cfYVuYnd/242-pre-release-text-files-not-show-full-information

Incorrect content length headers can be returned for content that is
gzipped.

Eg.

```
irb(main):001:0> http = Net::HTTP.new("www.w3.org", 443)
=> #<Net::HTTP www.w3.org:443 open=false>
irb(main):002:0> http.use_ssl = true
=> true
irb(main):003:0> request = Net::HTTP::Get.new("/")
=> #<Net::HTTP::Get GET>
irb(main):004:0> request.initialize_http_header({ "accept-encoding" => "gzip" })
=> {"accept-encoding"=>"gzip"}
irb(main):005:0> response = http.start { http.request(request) }
=> #<Net::HTTPOK 200 OK readbody=true>
irb(main):006:0> response["Content-Length"]
=> "9085"
irb(main):007:0> response.body.bytesize
=> 35437
```

Confusingly if you use `request["accept-encoding"] = "gzip"` above
Net::HTTP won't automatically decompress the value.