### PR TITLE
Remove app's logging config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,13 +77,6 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
-
-  $real_stdout = $stdout.clone
-  $stdout.reopen($stderr)
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new($real_stdout)
-  config.logstasher.suppress_app_log = true
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
This is now provided in [govuk_app_config's configuration](https://github.com/alphagov/govuk_app_config/blob/6f6c398b63585bb368fc54c39d64777022e1665b/lib/govuk_app_config/govuk_logging.rb)