### PR TITLE
Allow iframing draft content

### DIFF
--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -35,6 +35,7 @@ class Proxy < Rack::Proxy
   def rewrite_response(response)
     status, headers, body = response
 
+    allow_iframing(headers)
     fix_content_length(headers, body)
 
     [
@@ -106,5 +107,9 @@ private
       headers.delete(content_length_header)
     end
     bytesize = body.map(&:bytesize)
+  end
+
+  def allow_iframing(headers)
+    headers.delete('X-Frame-Options')
   end
 end

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe "Proxying requests", type: :request do
       expect(response["Location"]).to eq("http://www.example.com/auth/gds")
     end
 
+    it "allows iframing" do
+      stub_request(:get, upstream_uri + upstream_path).to_return(body: body, headers: { 'X-Frame-Options' => 'DENY' })
+
+      get upstream_path
+
+      expect(response.headers['X-Frame-Options']).to be_nil
+    end
+
     context "with a JWT token" do
       let(:jwt_auth_secret) { 'my$ecretK3y' }
       let(:auth_bypass_id) { SecureRandom.uuid }


### PR DESCRIPTION
We're working on a new publisher app. Part of that is a page in the publisher that shows the page in mobile and desktop format. To achieve this we'll probably have to iframe pages. Currently this is disallowed by default by Rails. This commit makes sure we strip the `X-Frame-Options` header so iframing becomes allowed again.

https://trello.com/c/QgznZEUJ