### PR TITLE
Set auth bypass token into a cookie

### DIFF
--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe "Proxying requests", type: :request do
         with(headers: { 'X-Govuk-Authenticated-User' => 'invalid' })
       end
 
+      it "sets a cookie with the auth bypass token" do
+        expect(response.cookies["auth_bypass_token"]).to eq(token)
+      end
+
+      it "sets the appropriate environment as the cookie domain" do
+        ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
+        get "#{upstream_path}?token=#{token}"
+        expect(response.headers["Set-Cookie"]).to match("domain=.integration.publishing.service.gov.uk")
+        ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
+      end
+
       context "with an invalid token" do
         let(:token) { JWT.encode({ 'sub' => auth_bypass_id }, 'invalid', 'HS256') }
         it "redirects the user for authentication" do


### PR DESCRIPTION
Trello: https://trello.com/c/dawXVwdW/439-asset-manager-files-are-not-available-when-using-access-tokens-or-if-someone-doesnt-have-asset-manager-permission

This is so that this token can be shared with other apps in the stack,
most notably asset manager. This aims to be the first step to resolving
a problem we have:

- A user can view a draft page with a token
- That page contains draft assets
- Those draft assets can't be viewed because the user is not authenticated.

It uses a cookie for this approach as it would be impractical to append
query strings to every asset in previewing a document.