### PR TITLE
Set authenticated user organisation header

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,9 @@
 # Create a default user for GDS::SSO
-user = User.new(name: "Bobby Bob", email: "bob@alphagov.co.uk")
+user = User.new(
+  name: "Bobby Bob",
+  email: "bob@alphagov.co.uk",
+  organisation_content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
+  uid: "b3351570-7af1-0137-91b6-02e3ce870912"
+)
 user.permissions = ["signin"]
 user.save!

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -29,6 +29,7 @@ class Proxy < Rack::Proxy
     # Proxying hangs in the VM unless the host header is explicitly overridden here.
     env['HTTP_HOST'] = upstream_url.host
     add_authenticated_user_header(env)
+    add_authenticated_user_organisation_header(env)
     env
   end
 
@@ -98,6 +99,14 @@ private
                                              else
                                                'invalid'
                                              end
+  end
+
+  def add_authenticated_user_organisation_header(env)
+    env['HTTP_X_GOVUK_AUTHENTICATED_USER_ORGANISATION'] = if env['warden'] && env['warden'].user
+                                                            env['warden'].user.organisation_content_id.to_s
+                                                          else
+                                                            'invalid'
+                                                          end
   end
 
   def healthcheck_path?(path)

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -51,6 +51,11 @@ RSpec.describe "Proxying requests", type: :request do
         with(headers: { 'X-Govuk-Authenticated-User' => 'invalid' })
       end
 
+      it "marks the user organisation id as invalid in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri + upstream_path + "?token=#{token}").
+        with(headers: { 'X-Govuk-Authenticated-User-Organisation' => 'invalid' })
+      end
+
       it "sets a cookie with the auth bypass token" do
         expect(response.cookies["auth_bypass_token"]).to eq(token)
       end
@@ -86,6 +91,7 @@ RSpec.describe "Proxying requests", type: :request do
 
   context "authenticated user" do
     let(:authenticated_user_uid) { User.first.uid }
+    let(:authenticated_org_content_id) { User.first.organisation_content_id }
     before do
       stub_request(:get, upstream_uri + upstream_path).to_return(body: body)
       get upstream_path
@@ -98,6 +104,11 @@ RSpec.describe "Proxying requests", type: :request do
     it "includes the user's UID in the upstream request headers" do
       expect(WebMock).to have_requested(:get, upstream_uri + upstream_path).
         with(headers: { 'X-Govuk-Authenticated-User' => authenticated_user_uid })
+    end
+
+    it "includes the user's organisation content-id in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri + upstream_path).
+        with(headers: { 'X-Govuk-Authenticated-User-Organisation' => authenticated_org_content_id })
     end
   end
 end


### PR DESCRIPTION
This is to allow access limiting via a users organisation content-id,
this is part of the work publishing workflow are doing to implement
access limiting. Validation will be done in the content-store on whether a user
belonging to a certain organisation can access a document in the draft stack.

Trello:
https://trello.com/c/wxp1XkSg/969-update-govuk-to-support-access-limiting-by-organisation