### PR TITLE
Proxy both authentication information and JWT token information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # GOV.UK Authenticating Proxy
 
-App to add authentication to the draft version of GOV.UK, so that only users with a [signon][] account can access it.
+App to add authentication to the draft version of GOV.UK, so that only users with
+a [signon][] account - or a valid JSON web token ([JWT]) - can access it.
 
 Some of the thinking behind this is [documented in RFC 13][rfc].
 
+[JWT]: https://jwt.io/
 [rfc]: https://github.com/alphagov/govuk-rfcs/blob/master/rfc-013-thoughts-on-access-limiting-in-draft.md
 
 ## Live examples
@@ -28,17 +30,20 @@ performing authentication using `gds-sso` to ensure that only authenticated
 users are able to view the site. It sets an `X-GOVUK-AUTHENTICATED-USER` header
 so that the upstream service can identify the user.
 
-The application also supports bypassing authentication via a valid JSON web token ([JWT]).
+The application also supports bypassing authentication via a valid JWT token.
 If the URL being requested includes a `token` querystring containing a valid
 token encoded with the value in the `JWT_AUTH_SECRET` environment variable, and
 that token contains a `sub` key, the value of that key is passed upstream in
-the `GOVUK_AUTH_BYPASS_ID` header and authentication is not performed.
-NB, the `sub` (or "subject") key is one of the [reserved claims of a JWT][].
+the `GOVUK_AUTH_BYPASS_ID` header. NB, the `sub` (or "subject") key is one of the
+[reserved claims of a JWT][].
+
+If a user is authenticated using `gds-sso` and a JWT token is also provided, both
+sets of information are passed upstream. It is up to the upstream application how
+to handle these cases.
 
 Authenticating-proxy does not itself check that the auth_bypass_id is actually
 valid; this will be done by content-store.
 
-[JWT]: https://jwt.io/
 [reserved claims of a JWT]: https://auth0.com/docs/tokens/jwt-claims#reserved-claims
 
 ### Dependencies

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -55,11 +55,16 @@ private
 
   def process_token_or_authenticate!(env)
     request = Rack::Request.new(env)
-    if token = request.params['token']
+    if token = request.params.fetch("token", get_auth_bypass_cookie(env))
       auth_bypass_id = process_token(token, env)
     end
     user = auth_bypass_id ? env['warden'].authenticate : env['warden'].authenticate!
     debug_logging(env, "authenticated as #{user.email}") if user
+  end
+
+  def get_auth_bypass_cookie(env)
+    cookie = Rack::Utils.parse_cookies(env)
+    cookie["auth_bypass_token"] if cookie
   end
 
   def set_auth_bypass_cookie(response, env)

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -26,8 +26,6 @@ class Proxy < Rack::Proxy
   end
 
   def rewrite_env(env)
-    # Proxying hangs in the VM unless the host header is explicitly overridden here.
-    env['HTTP_HOST'] = upstream_url.host
     add_authenticated_user_header(env)
     add_authenticated_user_organisation_header(env)
     env

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -92,11 +92,6 @@ private
   rescue JWT::DecodeError
   end
 
-  def authenticate!(env)
-    user = env['warden'].authenticate!
-    debug_logging(env, "authenticated as #{user.email}")
-  end
-
   def add_authenticated_user_header(env)
     env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = if env['warden'].user
                                                env['warden'].user.uid.to_s

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -87,14 +87,12 @@ private
   end
 
   def authenticate!(env)
-    if env['warden']
-      user = env['warden'].authenticate!
-      debug_logging(env, "authenticated as #{user.email}")
-    end
+    user = env['warden'].authenticate!
+    debug_logging(env, "authenticated as #{user.email}")
   end
 
   def add_authenticated_user_header(env)
-    env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = if env['warden'] && env['warden'].user
+    env['HTTP_X_GOVUK_AUTHENTICATED_USER'] = if env['warden'].user
                                                env['warden'].user.uid.to_s
                                              else
                                                'invalid'
@@ -102,7 +100,7 @@ private
   end
 
   def add_authenticated_user_organisation_header(env)
-    env['HTTP_X_GOVUK_AUTHENTICATED_USER_ORGANISATION'] = if env['warden'] && env['warden'].user
+    env['HTTP_X_GOVUK_AUTHENTICATED_USER_ORGANISATION'] = if env['warden'].user
                                                             env['warden'].user.organisation_content_id.to_s
                                                           else
                                                             'invalid'

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -56,9 +56,9 @@ private
   def process_token_or_authenticate!(env)
     request = Rack::Request.new(env)
     if token = request.params['token']
-      content_id = process_token(token, env)
+      auth_bypass_id = process_token(token, env)
     end
-    authenticate!(env) unless content_id
+    authenticate!(env) unless auth_bypass_id
   end
 
   def set_auth_bypass_cookie(response, env)

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -58,7 +58,8 @@ private
     if token = request.params['token']
       auth_bypass_id = process_token(token, env)
     end
-    authenticate!(env) unless auth_bypass_id
+    user = auth_bypass_id ? env['warden'].authenticate : env['warden'].authenticate!
+    debug_logging(env, "authenticated as #{user.email}") if user
   end
 
   def set_auth_bypass_cookie(response, env)

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -17,13 +17,9 @@ RSpec.describe Proxy do
   let(:proxy_app) { Proxy.new(inner_app, upstream_uri) }
 
   before do
+    stub_warden_authentication
     stub_request(:get, upstream_uri + upstream_path).
       to_return(body: upstream_body, status: 200, headers: upstream_headers)
-  end
-
-  it 'passes Rack::Lint checks' do
-    lint_app = Rack::Lint.new(Proxy.new(inner_app, upstream_uri))
-    lint_app.call(request_env)
   end
 
   it 'returns the response from the upstream URI' do
@@ -46,5 +42,20 @@ RSpec.describe Proxy do
       rewrote = proxy_app.rewrite_response(response)
       expect(rewrote).to match([status, { "Content-Length" => "19" }, body])
     end
+  end
+
+  def stub_warden_authentication
+    request_env["warden"] = double(
+      authenticate!: stub_user,
+      user: stub_user,
+    )
+  end
+
+  def stub_user
+    @stub_user ||= double(
+      uid: User.first.uid,
+      organisation_content_id: User.first.organisation_content_id,
+      email: "example@gov.uk"
+    )
   end
 end

--- a/spec/lib/proxy_spec.rb
+++ b/spec/lib/proxy_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Proxy do
 
   def stub_warden_authentication
     request_env["warden"] = double(
+      authenticate: stub_user,
       authenticate!: stub_user,
       user: stub_user,
     )

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -20,8 +20,6 @@ RSpec.describe "Proxying requests", type: :request do
     end
 
     it "allows iframing" do
-      stub_request(:get, upstream_uri + upstream_path).to_return(body: body, headers: { 'X-Frame-Options' => 'DENY' })
-
       get upstream_path
 
       expect(response.headers['X-Frame-Options']).to be_nil

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -158,4 +158,48 @@ RSpec.describe "Proxying requests", type: :request do
       ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
     end
   end
+
+  context "authenticated user with an invalid JWT token" do
+    let(:authenticated_user_uid) { User.first.uid }
+    let(:authenticated_org_content_id) { User.first.organisation_content_id }
+    let(:auth_bypass_id) { SecureRandom.uuid }
+    let(:jwt_auth_secret) { 'my$ecretK3y' }
+    let(:token) { JWT.encode({ 'sub' => auth_bypass_id }, 'invalid', 'HS256') }
+    let(:upstream_uri_with_token) { "#{upstream_uri}#{upstream_path}?token=#{token}" }
+
+    before do
+      allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
+      stub_request(:get, upstream_uri_with_token).to_return(body: body)
+      get "#{upstream_path}?token=#{token}"
+    end
+
+    it "proxies the request to the upstream server" do
+      expect(response.body).to eq(body)
+    end
+
+    it "does not redirect the user for authentication" do
+      expect(response.status).to eq(200)
+    end
+
+    it "includes the user's UID in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri_with_token).
+        with(headers: { 'X-Govuk-Authenticated-User' => authenticated_user_uid })
+    end
+
+    it "includes the user's organisation content-id in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri_with_token).
+        with(headers: { 'X-Govuk-Authenticated-User-Organisation' => authenticated_org_content_id })
+    end
+
+    it "sets a cookie with the auth bypass token" do
+      expect(response.cookies["auth_bypass_token"]).to eq(token)
+    end
+
+    it "sets the appropriate environment as the cookie domain" do
+      ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
+      get "#{upstream_path}?token=#{token}"
+      expect(response.headers["Set-Cookie"]).to match("domain=.integration.publishing.service.gov.uk")
+      ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
+    end
+  end
 end

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Proxying requests", type: :request do
       end
 
       context "with a token that is valid but doesn't contain the right key" do
-        let(:token) { JWT.encode({ 'foo' => 'bar' }, 'invalid', 'HS256') }
+        let(:token) { JWT.encode({ 'foo' => 'bar' }, jwt_auth_secret, 'HS256') }
         it "redirects the user for authentication" do
           get "#{upstream_path}?token=#{token}"
 

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe "Proxying requests", type: :request do
   let(:authenticated_user_uid) { User.first.uid }
   let(:authenticated_org_content_id) { User.first.organisation_content_id }
 
+  before do
+    allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
+  end
+
   shared_examples "sets auth-bypass token cookie" do
     it "sets the appropriate environment as the cookie domain" do
       ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
@@ -41,7 +45,6 @@ RSpec.describe "Proxying requests", type: :request do
 
     context "with a JWT token in URL query string" do
       before do
-        allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
         stub_request(:get, upstream_uri + upstream_path + "?token=#{token}").to_return(body: body)
         get "#{upstream_path}?token=#{token}"
       end
@@ -96,7 +99,6 @@ RSpec.describe "Proxying requests", type: :request do
       let(:cookie) { "auth_bypass_token=#{token}; Path=/; Domain=#{'.' + upstream_uri}" }
 
       before do
-        allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
         stub_request(:get, upstream_uri + upstream_path).to_return(body: body)
         get upstream_path, headers: { Cookie: cookie }
       end
@@ -147,7 +149,6 @@ RSpec.describe "Proxying requests", type: :request do
     let(:upstream_uri_with_token) { "#{upstream_uri}#{upstream_path}?token=#{token}" }
 
     before do
-      allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
       stub_request(:get, upstream_uri_with_token).to_return(body: body)
       get "#{upstream_path}?token=#{token}"
     end
@@ -187,7 +188,6 @@ RSpec.describe "Proxying requests", type: :request do
     let(:upstream_uri_with_token) { "#{upstream_uri}#{upstream_path}?token=#{token}" }
 
     before do
-      allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
       stub_request(:get, upstream_uri_with_token).to_return(body: body)
       get "#{upstream_path}?token=#{token}"
     end

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe "Proxying requests", type: :request do
   let(:upstream_path) { "/foo" }
   let(:upstream_uri) { ENV['GOVUK_UPSTREAM_URI'] }
 
+  shared_examples "sets auth-bypass token cookie" do
+    it "sets the appropriate environment as the cookie domain" do
+      ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
+      get "#{upstream_path}?token=#{token}"
+      expect(response.headers["Set-Cookie"]).to match("domain=.integration.publishing.service.gov.uk")
+      ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
+    end
+  end
+
   context "unauthenticated user" do
     around do |example|
       ENV['GDS_SSO_MOCK_INVALID'] = '§1'
@@ -58,12 +67,7 @@ RSpec.describe "Proxying requests", type: :request do
         expect(response.cookies["auth_bypass_token"]).to eq(token)
       end
 
-      it "sets the appropriate environment as the cookie domain" do
-        ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
-        get "#{upstream_path}?token=#{token}"
-        expect(response.headers["Set-Cookie"]).to match("domain=.integration.publishing.service.gov.uk")
-        ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
-      end
+      include_examples "sets auth-bypass token cookie"
 
       context "with an invalid token" do
         let(:token) { JWT.encode({ 'sub' => auth_bypass_id }, 'invalid', 'HS256') }
@@ -151,12 +155,7 @@ RSpec.describe "Proxying requests", type: :request do
       expect(response.cookies["auth_bypass_token"]).to eq(token)
     end
 
-    it "sets the appropriate environment as the cookie domain" do
-      ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
-      get "#{upstream_path}?token=#{token}"
-      expect(response.headers["Set-Cookie"]).to match("domain=.integration.publishing.service.gov.uk")
-      ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
-    end
+    include_examples "sets auth-bypass token cookie"
   end
 
   context "authenticated user with an invalid JWT token" do
@@ -195,11 +194,6 @@ RSpec.describe "Proxying requests", type: :request do
       expect(response.cookies["auth_bypass_token"]).to eq(token)
     end
 
-    it "sets the appropriate environment as the cookie domain" do
-      ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
-      get "#{upstream_path}?token=#{token}"
-      expect(response.headers["Set-Cookie"]).to match("domain=.integration.publishing.service.gov.uk")
-      ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
-    end
+    include_examples "sets auth-bypass token cookie"
   end
 end

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Proxying requests", type: :request do
       context "with an invalid token" do
         let(:token) { JWT.encode({ 'sub' => auth_bypass_id }, 'invalid', 'HS256') }
         it "redirects the user for authentication" do
-          get upstream_path
+          get "#{upstream_path}?token=#{token}"
 
           expect(response.status).to eq(302)
           expect(response["Location"]).to eq("http://www.example.com/auth/gds")
@@ -80,7 +80,7 @@ RSpec.describe "Proxying requests", type: :request do
       context "with a token that is valid but doesn't contain the right key" do
         let(:token) { JWT.encode({ 'foo' => 'bar' }, 'invalid', 'HS256') }
         it "redirects the user for authentication" do
-          get upstream_path
+          get "#{upstream_path}?token=#{token}"
 
           expect(response.status).to eq(302)
           expect(response["Location"]).to eq("http://www.example.com/auth/gds")

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -109,4 +109,53 @@ RSpec.describe "Proxying requests", type: :request do
         with(headers: { 'X-Govuk-Authenticated-User-Organisation' => authenticated_org_content_id })
     end
   end
+
+  context "authenticated user with a valid JWT token" do
+    let(:authenticated_user_uid) { User.first.uid }
+    let(:authenticated_org_content_id) { User.first.organisation_content_id }
+    let(:jwt_auth_secret) { 'my$ecretK3y' }
+    let(:auth_bypass_id) { SecureRandom.uuid }
+    let(:token) { JWT.encode({ 'sub' => auth_bypass_id }, jwt_auth_secret, 'HS256') }
+    let(:upstream_uri_with_token) { "#{upstream_uri}#{upstream_path}?token=#{token}" }
+
+    before do
+      allow_any_instance_of(Proxy).to receive(:jwt_auth_secret).and_return(jwt_auth_secret)
+      stub_request(:get, upstream_uri_with_token).to_return(body: body)
+      get "#{upstream_path}?token=#{token}"
+    end
+
+    it "proxies the request to the upstream server" do
+      expect(response.body).to eq(body)
+    end
+
+    it "does not redirect the user for authentication" do
+      expect(response.status).to eq(200)
+    end
+
+    it "includes the user's UID in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri_with_token).
+        with(headers: { 'X-Govuk-Authenticated-User' => authenticated_user_uid })
+    end
+
+    it "includes the user's organisation content-id in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri_with_token).
+        with(headers: { 'X-Govuk-Authenticated-User-Organisation' => authenticated_org_content_id })
+    end
+
+    it "includes the decoded auth_bypass_id in the upstream request headers" do
+      expect(WebMock).to have_requested(:get, upstream_uri_with_token).
+        with(headers: { 'Govuk-Auth-Bypass-Id' => auth_bypass_id })
+    end
+
+    it "sets a cookie with the auth bypass token" do
+      expect(response.cookies["auth_bypass_token"]).to eq(token)
+    end
+
+    it "sets the appropriate environment as the cookie domain" do
+      ENV["GOVUK_APP_DOMAIN_EXTERNAL"] = "integration.publishing.service.gov.uk"
+      get "#{upstream_path}?token=#{token}"
+      expect(response.headers["Set-Cookie"]).to match("domain=.integration.publishing.service.gov.uk")
+      ENV.delete("GOVUK_APP_DOMAIN_EXTERNAL")
+    end
+  end
 end

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe "Proxying requests", type: :request do
         end
       end
 
+      context "with a token that is rejected by the service" do
+        it "redirects the user for authentication" do
+          stub_request(:get, upstream_uri + upstream_path + "?token=#{token}").to_return(body: body, status: 403)
+          get "#{upstream_path}?token=#{token}"
+
+          expect(response.status).to eq(302)
+          expect(response["Location"]).to eq("http://www.example.com/auth/gds")
+        end
+      end
+
       context "with a token that is valid but doesn't contain the right key" do
         let(:token) { JWT.encode({ 'foo' => 'bar' }, jwt_auth_secret, 'HS256') }
         it "redirects the user for authentication" do


### PR DESCRIPTION
authenticating-proxy used to work on an either/or basis: logged in
users with a JWT token would not have any authentication information
proxied, so if the JWT token is invalid/expired/unauthenticated, they
would not be able to access the content, even if they are otherwise
authorised to do so.

This risked causing confusion when we come to implement persisting
tokens as a cookie, as authenticated users would have little idea
that the token is being used rather than their authentication.

Trello: https://trello.com/c/wAcvEyKm/143-change-authenticating-proxy-access-logic-to-consider-users-signed-in-and-have-an-auth-bypass-token