### PR TITLE
Authenticate user if not logged in and token is rejected

### DIFF
--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -26,8 +26,6 @@ class Proxy < Rack::Proxy
   end
 
   def rewrite_env(env)
-    # Proxying hangs in the VM unless the host header is explicitly overridden here.
-    env['HTTP_HOST'] = upstream_url.host
     add_authenticated_user_header(env)
     add_authenticated_user_organisation_header(env)
     env

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Proxying requests", type: :request do
       end
 
       context "with a token that is valid but doesn't contain the right key" do
-        let(:token) { JWT.encode({ 'foo' => 'bar' }, 'invalid', 'HS256') }
+        let(:token) { JWT.encode({ 'foo' => 'bar' }, jwt_auth_secret, 'HS256') }
         it "redirects the user for authentication" do
           get "#{upstream_path}?token=#{token}"
 

--- a/spec/requests/proxying_spec.rb
+++ b/spec/requests/proxying_spec.rb
@@ -84,6 +84,16 @@ RSpec.describe "Proxying requests", type: :request do
         end
       end
 
+      context "with a token that is rejected by the service" do
+        it "redirects the user for authentication" do
+          stub_request(:get, upstream_uri + upstream_path + "?token=#{token}").to_return(body: body, status: 403)
+          get "#{upstream_path}?token=#{token}"
+
+          expect(response.status).to eq(302)
+          expect(response["Location"]).to eq("http://www.example.com/auth/gds")
+        end
+      end
+
       context "with a token that is valid but doesn't contain the right key" do
         let(:token) { JWT.encode({ 'foo' => 'bar' }, jwt_auth_secret, 'HS256') }
         it "redirects the user for authentication" do


### PR DESCRIPTION
If you visit a draft page which your token does not allow access to,
rather than showing a "You do not have permission to view this page"
error, we should redirect the user to signon.

This is to prevent issues where a content designer previews a step
by step (which sets the cookie), then indirectly view some other
draft content (without a token in the URL), thereby falling back on
the cookie token which is not compatible with that particular draft
content. Prior to storing tokens as a cookie, the user would be
redirected to signon, so by storing tokens as a cookie, we'll have
caused a regression. This PR keeps the behaviour as it was.

Trello: https://trello.com/c/wAcvEyKm/143-change-authenticating-proxy-access-logic-to-consider-users-signed-in-and-have-an-auth-bypass-token