### PR TITLE
Fixes for GOV.UK Docker

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,16 +1,12 @@
 development:
   clients:
     default:
-      database: authenticating_proxy_development
-      hosts:
-        - <%= ENV.fetch("MONGODB_URI", "localhost:27017") %>
+      uri: <%= ENV.fetch("MONGODB_URI", "mongodb://localhost:27017/authenticating_proxy_development") %>
 
 test:
   clients:
     default:
-      database: authenticating_proxy_test
-      hosts:
-        - <%= ENV.fetch("MONGODB_URI", "localhost:27017") %>
+      uri: <%= ENV.fetch("TEST_MONGODB_URI", "mongodb://localhost:27017/authenticating_proxy_test") %>
       options:
         read:
           mode: :primary

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -27,6 +27,8 @@ class Proxy < Rack::Proxy
   end
 
   def rewrite_env(env)
+    # HTTP HOST header removed as it can supersede backend host
+    env.delete("HTTP_HOST")
     add_authenticated_user_header(env)
     add_authenticated_user_organisation_header(env)
     env


### PR DESCRIPTION
This introduces a couple of fixes to allow this app to work in GOV.UK Docker.

First it fixes the mess I made with https://github.com/alphagov/authenticating-proxy/pull/166 - sorry

And introduces a variance on the change that was reverted in https://github.com/alphagov/authenticating-proxy/commit/aad8d6d75bac0c336195e434d43049969d75a35b#diff-de4c13211691eb0fbfe4b0e1f627a638 and explains why this is needed still.