### PR TITLE
Add note about JWT not being encrpyted

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ it should expire.
 In addition to the JWT standard fields, you can encode arbitrary fields which might
 only have meaning for your application. For example, it is recommended that you store
 some information that describes the piece of content associated with the JWT token (such
-as a content ID).
+as a content ID). Do bear in mind that the data inside a JWT token is not encrypted
+and **must** not include sensitive or personally identifiable data.
 
 ```
   "content_id" => step_by_step.content_id


### PR DESCRIPTION
It was news to me that this was not encrypted and the data could actually be decoded and read by anybody. I've not got any evidence that we've used these tokens for sensitive data but feel it's prudent to leave a note for others so they don't then use this to include sensitive information.