### PR TITLE
Use MongoDB 3.2 for testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node {
+node ('mongodb-3.2') {
   govuk.buildProject(
     beforeTest: {
       govuk.setEnvar("GOVUK_UPSTREAM_URI", "http://test.example.com")


### PR DESCRIPTION
We're using Amazon DocumentDB in Production, which apparently is
compatible with MongoDB 3.6, so use the version closest to this of
MongoDB for testing.