### PR TITLE
Use MongoDB 2.4 for tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node ('mongodb-3.2') {
+node ('mongodb-2.4') {
   govuk.buildProject(
     beforeTest: {
       govuk.setEnvar("GOVUK_UPSTREAM_URI", "http://test.example.com")


### PR DESCRIPTION
As this matches what's used in Production. I did think before that
Authenticating Proxy was using Amazon DocumentDB, but this was just
because I missed that it was using the MongoDB 2.4 instances on the
router_backend machines.