### PR TITLE
Remove issuer documentation; add content_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,24 +107,29 @@ is a dependency of gds-sso via oauth2 - to encode a token as follows:
 ```
 JWT.encode({
   "sub" => auth_bypass_id,
-  "iss" => current_user.uid,
   "iat" => Time.zone.now.to_i,
   "exp" => 1.month.from_now.to_i,
+  "content_id" => content_id,
 }, ENV['JWT_AUTH_SECRET'], 'HS256')
 ```
 
 Where:
 
-- `sub` value of `auth_bypass_id` is the UUID for the auth bypass of the content item
-- `iss` ("issuer") is the unique ID of the user who created the token
+- `sub` value of `auth_bypass_id` is a unique value determined by the publishing
+  application for a particular draft piece of content
 - `iat` ("issued at") is the time at which the token was created
-- `exp` ("expiration time") is when the token should expire and no longer be valid
+- `exp` ("expiration time") is when the token should expire and no longer be
+   valid
+- `content_id` is the GOV.UK content id for the piece of content that is being
+  shared
 
-These fields are [registered claim names][] in the JWT specification. Providing
-them is recommended as they help to audit when and how the token was created and when
-it should expire.
+`sub`, `iat` and `exp` [registered claims][] as part of the JWT specification.
+Applications are advised to use an expiry on tokens to limit their lifespan
+and set an auth_bypass_id that is relatively simple to rotate were a token
+to be accidentally made public. The `iat` and `content_id` values allow tracing
+the source of a token.
 
-[registered claim names]: https://tools.ietf.org/html/rfc7519#section-4.1
+[registered claim]: https://tools.ietf.org/html/rfc7519#section-4.1
 
 #### Optional special fields
 


### PR DESCRIPTION
This reflects that the guidance on using a user id as an issuer wasn't
representative of the common usage of the field - which is more
commonly used to represent an organisation. Including the user id also
potentially opens up some privacy concerns depending on interpretation
of legislation regarding private ids. The simplest approach is to
remove this value and only consider adding it to guidance when we have
evidence that it is important.

This also updates the definition of the subject to refer to how it
should be unique for an edition of a piece of content, which
differentiates it from some current usages where the same one is used
for all editions.

It also includes the usage of content_id which is suggested to help
identify any tokens that go astray. I'm hoping the combination of
content_id and time can make it possible to track tokens to a request
despite not knowing the user id.

I've made these amends following the incident on 30th June 2020 where
Leicester City Council tweeted a link with an auth_bypass_token.