### PR TITLE
Add pull request template since enabling CD

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+:warning: This application is Continuously Deployed: :warning:
+
+- Merged changes are automatically deployed to staging and production.
+
+- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.
+
+- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/authenticating-proxy), after merging.


### PR DESCRIPTION
This app is deployed [using CD now](https://github.com/alphagov/govuk-puppet/pull/10843), so we should add a warning.