### PR TITLE
Don't proxy RFC 141 healthcheck paths

### DIFF
--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -111,7 +111,7 @@ private
   end
 
   def healthcheck_path?(path)
-    path == "/healthcheck"
+    %w[/healthcheck /healthcheck/live /healthcheck/ready].include? path
   end
 
   def gds_sso_path?(path)


### PR DESCRIPTION
authenticating-proxy checks that a user is logged in and, if so,
proxies their request to the draft stack.  If the user isn't logged
in, they get redirected to signon to authenticate.

This doesn't work for healthcheck requests, because they need to be
handled by the app.  So there's a check for whether the user is
requesting "/healthcheck".

406106d added a couple more healthcheck routes, so those also
need including in the check.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
