### PR TITLE
Add basic Dockerfile to integrate app in GOV.UK ECS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.7.2
+
+RUN apt-get update -qq && apt-get upgrade -y
+RUN apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
+
+ENV GOVUK_APP_NAME authenticating-proxy
+ENV PORT 3107
+ENV RAILS_ENV production
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+
+WORKDIR $APP_HOME
+ADD Gemfile* $APP_HOME/
+ADD .ruby-version $APP_HOME/
+RUN bundle install
+
+ADD . $APP_HOME
+
+CMD foreman run web

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3107}


### PR DESCRIPTION
We add a rudimentary Dockerfile to be able to test the integration
of the authentication-proxy app in the draft stack of the new
GOV.UK ECS platform.

It is not intended for this Dockerfile to be used in Production,
this will be done after this [work](https://trello.com/c/GMS8H1bN/426-building-containers-documenting-follow-up) is completed.

This Dockefile was tested by building the image and testing it with
govuk-infrastructure [PR](https://github.com/alphagov/govuk-infrastructure/pull/251)

Ref:
1. [task trello card](https://trello.com/c/vYNGbJSN/493-add-authenticating-proxy-to-the-draft-stack)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
