### PR TITLE
Enable CI in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Test Rails
+    uses: alphagov/govuk-infrastructure/.github/workflows/test-rails.yaml@main
+    with:
+      requiresMongoDB: true
+    env:
+      GOVUK_UPSTREAM_URI: http://test.example.com

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,5 +12,3 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/test-rails.yaml@main
     with:
       requiresMongoDB: true
-    env:
-      GOVUK_UPSTREAM_URI: http://test.example.com

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,19 +17,18 @@ on:
         - staging
         - production
         default: 'integration'
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   build-and-publish-image:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     with:
-      gitRef: ${{ github.event.inputs.gitRef }}
+      gitRef: ${{ github.event.inputs.gitRef || github.ref }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
@@ -39,7 +38,6 @@ jobs:
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
-      workflowTrigger: ${{ github.event_name }}
       environment: ${{ github.event.inputs.environment }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "plek"
 gem "rack-proxy"
 
 group :development, :test do
+  gem "brakeman"
   gem "byebug"
   gem "climate_control"
   gem "rack-test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    brakeman (5.2.3)
     bson (4.15.0)
     builder (3.2.4)
     byebug (11.1.3)
@@ -305,6 +306,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brakeman
   byebug
   climate_control
   gds-sso

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,4 +47,5 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+  ENV["GOVUK_UPSTREAM_URI"] = "http://test.example.com"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 ENV["RAILS_ENV"] ||= "test"
-ENV["GOVUK_UPSTREAM_URI"] = "http://upstream-host.com"
 
 require "simplecov"
 SimpleCov.start "rails"


### PR DESCRIPTION
This workflow enables CI (tests, linting and security checks) using GitHub Actions. This apart of work to migrate the CI process from Jenkins to GitHub Actions. This doesn't migrate end to end tests as they've been deprecated. This also doesn't contain the process for creating a new release - this remains the responsibility of Jenkins. We needed to migrate the tests as we should be running tests on merge commit on the main branch before deploy them to our new infrastructure.
