### PR TITLE
Documentdb support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "rails", "7.0.3"
 
 gem "gds-sso"
 gem "govuk_app_config"
-gem "mongo", "2.15.1"
+gem "mongo"
 gem "mongoid"
 gem "plek"
 gem "rack-proxy"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    bson (4.14.1)
+    bson (4.15.0)
     builder (3.2.4)
     byebug (11.1.3)
     climate_control (1.0.1)
@@ -123,7 +123,7 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.15.0)
-    mongo (2.15.1)
+    mongo (2.17.1)
       bson (>= 4.8.2, < 5.0.0)
     mongoid (7.4.0)
       activemodel (>= 5.1, < 7.1, != 7.0.0)
@@ -305,7 +305,7 @@ DEPENDENCIES
   climate_control
   gds-sso
   govuk_app_config
-  mongo (= 2.15.1)
+  mongo
   mongoid
   plek
   rack-proxy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node ('mongodb-2.4') {
+node ('mongodb-4.0') {
   govuk.buildProject(
     beforeTest: {
       govuk.setEnvar("GOVUK_UPSTREAM_URI", "http://test.example.com")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node ('mongodb-4.0') {
+node ('mongodb-3.2') {
   govuk.buildProject(
     beforeTest: {
       govuk.setEnvar("GOVUK_UPSTREAM_URI", "http://test.example.com")

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ the same as requesting `government-frontend.dev.gov.uk`.
 bundle exec rake
 ```
 
+### MongoDB vs documentDB
+
+In GOV.UK Docker and in CI the app runs against MongoDB 4.0, but in production
+it attaches to a DocumentDB cluster (a "Mongo 4.0-compatible" wrapper over one
+or more Aurora instances). For most purposes this is fine, but if you make any
+serious changes you may want to run your local tests or dev machine against a
+real DocumentDB cluster. Instructions in the docs: [documentdb](docs/documentdb) 
+
+
+
 ### Further documentation
 
 Check the [`docs/`](docs/) directory.

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -2,12 +2,17 @@ development:
   clients:
     default:
       uri: <%= ENV.fetch("MONGODB_URI", "mongodb://localhost:27017/authenticating_proxy_development") %>
+      options:
+        direct_connection: <%= ENV.fetch("MONGODB_DIRECT_CONNECTION", 'false').downcase == 'true' %>
+        retry_writes: false
 
 test:
   clients:
     default:
       uri: <%= ENV.fetch("TEST_MONGODB_URI", "mongodb://localhost:27017/authenticating_proxy_test") %>
       options:
+        direct_connection: <%= ENV.fetch("MONGODB_DIRECT_CONNECTION", 'false').downcase == 'true' %>
+        retry_writes: false
         read:
           mode: :primary
 
@@ -16,7 +21,8 @@ production:
     default:
       uri: <%= ENV["MONGODB_URI"] %>
       options:
-        write:
-          w: majority
         read:
           mode: :primary_preferred
+        retry_writes: false
+        write:
+          w: majority

--- a/docs/documentdb.md
+++ b/docs/documentdb.md
@@ -1,0 +1,56 @@
+# DocumentDB
+
+As of June 2022, there are no docker containers available for documentdb, so in
+GOV.UK Docker and in CI the app runs against a vanilla MongoDB 4.0 instance.
+
+For most purposes this is okay, but if there are major Mongo or Mongoid gem
+updates it would probably be wise to test them against an actual DocumentDB
+cluster. This presents a few issues:
+
+- As above, no docker containers for DocumentDB
+- Also, it appears DocumentDB clusters *cannot* be allowed to listen to the
+  internet. (Even if you add a security rule to that end, it will be ignored)
+
+The clusters are set up so that they can be accessed by db_admin class machines,
+so the solution is to use SSH tunnelling through the machine, and tell
+authenticating proxy to run in direct connection mode (in which it simply
+connects to the mongo uri supplied and does not attempt to determine topology
+and connect to a preferred primary or secondary).
+
+To set up the tunnel, you will need to find out:
+
+- the hostname for the DocumentDB cluster. This should be in govuk-secrets
+- the ssh command for connecting through the jumpbox to the db_admin machine.
+  You can find that out by using the gds-cli:
+  `gds govuk connect ssh -e integration db_admin` - as this runs, it will print
+  out **Running Command:** followed by an ssh command. Take that command, and add
+  ` -N -L 37017:<cluster hostname>:27107`
+
+You should end up with something like this:
+
+```
+ssh -J yourname@jumpbox.integration.publishing.service.gov.uk \
+  yourname@ip-10-1-0-1.eu-west-1.compute.internal -N -L \
+  37017:authenticating-proxy-documentdb-integration.cluster.docdb.amazonaws.com:27017
+```
+
+Run that (it will block), and open another terminal. If you have mongo shell
+installed, you can test your tunnel by running:
+
+`mongo mongodb://localhost:37107`
+
+...if it connects, the tunnel is set up correctly.
+
+Now you'll need the username and password for the DocumentDB cluster (also in govuk-secrets)
+
+Finally, you can run:
+
+```
+govuk-docker run
+  -e TEST_MONGODB_URI=mongodb://<*documentdb_username*>:<*documentdb_password*>@host.docker.internal:37017/authenticating_proxy_test \
+  -e GOVUK_UPSTREAM_URI=http://government-frontend.dev.gov.uk \
+  -e MONGODB_DIRECT_CONNECTION=true authenticating-proxy-lite bundle exec rake
+```
+
+(host.docker.internal being docker's way of accessing the host machine, ie 
+localhost)


### PR DESCRIPTION
This update adds support for testing against a real DocumentDB cluster, and updates the CI tests to use Mongo 4.0 (which isn't DocumentDB, but is close enough for the tests to be valid).

This work is necessary to move authenticating proxy onto its own DocumentDB instance and away from the mongo-2.6 EC2 instance it's currently sharing with router and router-api.

https://trello.com/c/lSpntlfk/81-mongo-26-has-reached-end-of-life

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
