### PR TITLE
Dockerfile cleanup + enable bootsnap.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.dockerignore
+.git
+.gitignore
+.github
+Dockerfile
+Jenkinsfile
+Procfile
+README.md
+coverage
+docs
+log
+spec
+tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
+ARG ruby_version=3.1.2
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
 
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
-
-COPY . /app
+COPY . .
 
 
 FROM $base_image
 
-ENV GOVUK_APP_NAME=authenticating-proxy PORT=3107
+ENV GOVUK_APP_NAME=authenticating-proxy
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD ["bundle", "exec", "puma"]
+CMD ["puma"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
+RUN bootsnap precompile --gemfile .
 
 
 FROM $base_image
@@ -17,6 +18,7 @@ ENV GOVUK_APP_NAME=authenticating-proxy
 
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
 COPY --from=builder $APP_HOME .
 
 USER app

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.0.4"
 
+gem "bootsnap", require: false
 gem "gds-sso"
 gem "govuk_app_config"
 gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    bootsnap (1.15.0)
+      msgpack (~> 1.2)
     brakeman (5.4.0)
     bson (4.15.0)
     builder (3.2.4)
@@ -131,6 +133,7 @@ GEM
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.10.5, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
+    msgpack (1.6.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
       net-protocol
@@ -295,6 +298,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bootsnap
   brakeman
   byebug
   climate_control

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
- Use bootsnap to reduce startup resource usage spike.
- Parameterise Ruby version.
- Make better use of WORKDIR.
- Use env vars from the base image where appropriate, instead of hardcoding paths.
- Remove unnecessary use of `bundle exec`.
- Add .dockerignore.

Tested: app boots successfully with `docker run`.