### PR TITLE
Avoid installing unnecessary libpq-dev package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
 
 FROM $builder_image AS builder
-RUN apt-get update -qq && apt-get upgrade -y
-RUN apt-get install -y libpq-dev && apt-get clean
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
@@ -15,8 +13,6 @@ RUN bootsnap precompile --gemfile .
 
 
 FROM $base_image
-RUN apt-get update -qq && apt-get upgrade -y
-RUN apt-get install -y libpq-dev && apt-get clean
 
 ENV GOVUK_APP_NAME=authenticating-proxy
 


### PR DESCRIPTION
govuk-ruby-base [already includes libpq5](https://github.com/alphagov/govuk-ruby-images/blob/f04f773/base.Dockerfile#L131), which is the package that directly [contains the Postgres client shared library](https://packages.ubuntu.com/jammy/amd64/libpq5/filelist).

[libpq-dev](https://packages.ubuntu.com/jammy/libpq-dev) indirectly installs the shared lib but its main purpose is to install the [headers and so on](https://packages.ubuntu.com/jammy/amd64/libpq-dev/filelist), which are not needed at runtime. As a rule of thumb, `-dev` packages in general should not be necessary at runtime.

This saves significant time and resources at build-time because we no longer have to fetch the entire APT catalogue on each build stage.

Reverts c1bf90b; fixes a build-time performance regression introduced in #350.