### PR TITLE
Add X-Forwarded-Host header

### DIFF
--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -27,6 +27,8 @@ class Proxy < Rack::Proxy
   end
 
   def rewrite_env(env)
+    env["HTTP_X_FORWARDED_HOST"] = env["HTTP_HOST"]
+
     # HTTP HOST header removed as it can supersede backend host
     env.delete("HTTP_HOST")
     add_authenticated_user_header(env)


### PR DESCRIPTION
This ensures we pass on the original domain to Rails in the X-Forwarded-Host, which is used by the redirect_to methods in Rails frontend applications to generate redirect URLs. This is needed by pages such as simple smart answers, as Rails redirects user to the next applicable page. Previously, this was broken because frontend Rails only had the Host header to generate redirect URLs and this was being set to the internal domain 'draft-router'.

Tested in integration.
