### PR TITLE
Remove deprecated Jenkinsfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 .gitignore
 .github
 Dockerfile
-Jenkinsfile
 Procfile
 README.md
 coverage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,0 @@
-#!/usr/bin/env groovy
-
-library("govuk")
-
-node {
-  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/authenticating-proxy-test")
-  govuk.buildProject()
-}


### PR DESCRIPTION
We no longer use Jenkins for testing, and the file needs to be removed to prevent github from reassigning jenkins jobs to the branch settings.

https://trello.com/c/nLIJ54Qs/1746-remove-jenkinsfile-from-our-branches-s

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
