### PR TITLE
Prepare for upgrade to rails 7.1

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ require "gds-sso/user"
 
 class User < ApplicationRecord
   include GDS::SSO::User
-  serialize :permissions, Array
+  serialize :permissions, type: Array
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,22 +23,5 @@ module AuthenticatingProxy
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-
-    # Rotate SHA1 cookies to SHA256 (the new Rails 7 default)
-    # TODO: Remove this after existing user sessions have been rotated
-    # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256
-    Rails.application.config.action_dispatch.cookies_rotations.tap do |cookies|
-      salt = Rails.application.config.action_dispatch.authenticated_encrypted_cookie_salt
-      secret_key_base = Rails.application.secrets.secret_key_base
-      next if secret_key_base.blank?
-
-      key_generator = ActiveSupport::KeyGenerator.new(
-        secret_key_base, iterations: 1000, hash_digest_class: OpenSSL::Digest::SHA1
-      )
-      key_len = ActiveSupport::MessageEncryptor.key_len
-      secret = key_generator.generate_key(salt, key_len)
-
-      cookies.rotate :encrypted, secret
-    end
   end
 end


### PR DESCRIPTION
These changes preemptively avoid two deprecation warnings that appear when we upgrade to Rails 7.1:

> DEPRECATION WARNING: Passing the class as positional argument is deprecated and will be removed in Rails 7.2.

and

> DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from block in <class:Application> at /govuk/authenticating-proxy/config/application.rb:32)