### PR TITLE
Upgrade Ruby v3.1.2 -> v3.2.2 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.1.2
+ARG ruby_version=3.2.2
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
This was missed in #515 and I think it means we haven't actually been running the app on v3.2.2 after that PR was merged.

c.f. https://github.com/alphagov/signon/pull/2588
