### PR TITLE
Configure dependabot to monitor GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: daily
     allow:
       - dependency-type: "all"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
I saw that @brucebolt had added this to a number of other repos (e.g. https://github.com/alphagov/collections/pull/3495) and thought it made sense to add it here too.

More information in the [GitHub Docs][1].

[1]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
