### PR TITLE
Put response body in array

### DIFF
--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -153,6 +153,6 @@ private
   def rescue_invalid_request
     yield
   rescue Rack::Multipart::EmptyContentError
-    rewrite_response([400, {}, ""])
+    rewrite_response([400, {}, [""]])
   end
 end


### PR DESCRIPTION
The `rewrite_response` method is expecting an array for the body.

This was missed in https://github.com/alphagov/authenticating-proxy/pull/929 and resolves https://govuk.sentry.io/issues/5861864165/.