### PR TITLE
[PP-7685] Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,20 @@ updates:
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25
+
+  # Ruby needs to be upgraded manually in multiple places, so cannot
+  # be upgraded by Dependabot. That effectively makes the below
+  # config redundant, as ruby is the only updatable thing in the
+  # Dockerfile, although this may change in the future. We hope this
+  # config will save a dev from trying to upgrade ruby via Dependabot.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    ignore:
+      - dependency-name: ruby
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       - dependency-type: "all"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -28,3 +29,4 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,12 @@ updates:
       interval: daily
     allow:
       - dependency-type: "all"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 3
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: tuesday
       time: "07:00"
     allow:
-      - dependency-type: "all"
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     allow:
       - dependency-type: "all"
     cooldown:
@@ -20,7 +22,9 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
-    schedule:
-      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
       - dependency-type: "all"
     cooldown:
       default-days: 3
+    groups:
+      test:
+        patterns:
+          - "climate_control"
+          - "govuk_test"
+          - "rack-test"
+          - "rspec-*"
+          - "simplecov"
+          - "webmock"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It adds Docker support (while ignoring Ruby, which must be upgraded manually), introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes. 

Security updates remain unaffected and continue to be raised immediately.
